### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,16 +30,16 @@
     "test": "jest"
   },
   "dependencies": {
-    "@hapi/joi": "^16.1.7",
+    "@hapi/joi": "^16.1.8",
     "is": "^3.3.0"
   },
   "devDependencies": {
-    "eslint": "^6.6.0",
-    "eslint-config-prettier": "^6.7.0",
-    "eslint-plugin-jest": "^23.0.4",
-    "jest": "^24.9.0",
-    "jest-junit": "^9.0.0",
-    "knex": "^0.20.2",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-jest": "^23.6.0",
+    "jest": "^25.1.0",
+    "jest-junit": "^10.0.0",
+    "knex": "^0.20.8",
     "npm-run-all": "^4.1.5",
     "prettier": "1.19.1",
     "release-it": "^12.4.3"


### PR DESCRIPTION
Not upgrading to Joi v17, as it drops support for Node.js v8 and v10.