### PR TITLE
Permit `null` filter value for `is`, `is not`

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -150,10 +150,10 @@ formats are supported:
 
 - `operator` can be optional if the adapter specifies a default operator. If
   not, `operator` is required. `=` is the default operator for the Knex adapter.
-- `value` can be a string, number, boolean, array, or object. If an object,
-  however, the `operator` must be specified to avoid ambiguity. Each adapter can
-  add additional validation to restrict the `value` of a specific `operator`.
-  For example, an `in` operator might require an array `value`.
+- `value` can be a string, number, boolean, array, object, or `null`. If an
+  object, however, the `operator` must be specified to avoid ambiguity. Each
+  adapter can add additional validation to restrict the `value` of a specific
+  `operator`. For example, an `in` operator might require an array `value`.
 
 ### Supported Operators
 

--- a/src/parsers/filter.js
+++ b/src/parsers/filter.js
@@ -27,6 +27,7 @@ class FilterParser extends BaseParser {
       schema.boolean(),
       schema.number(),
       schema.string(),
+      schema.valid(null),
     ]
 
     return schema.object().keys(

--- a/test/src/parsers/filter.js
+++ b/test/src/parsers/filter.js
@@ -101,16 +101,26 @@ describe('validation', () => {
     expect(() => parser.validate()).not.toThrow()
   })
 
+  test('permits a null value', () => {
+    const parser = new FilterParser(
+      'filter',
+      { valid: { '=': null } },
+      new Schema().filter('valid', '=')
+    )
+
+    expect(() => parser.validate()).not.toThrow()
+  })
+
   test('throws for a non-permitted value', () => {
     const parser = new FilterParser(
       'filter',
-      { invalid: { '=': null } },
+      { invalid: { '=': {} } },
       new Schema().filter('invalid', '=')
     )
 
     expect(() => parser.validate()).toThrow(
       new ValidationError(
-        'filter:invalid[=] must be one of [array, boolean, number, string]'
+        'filter:invalid[=] must be one of [array, boolean, number, string, null]'
       )
     )
   })


### PR DESCRIPTION
Fixes #9.