### PR TITLE
Allow filter:[not ]between strings in Knex

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -178,8 +178,8 @@ That said, the default Knex adapter supports the following operators/values:
 - `not like`: string
 - `ilike`: string
 - `not ilike`: string
-- `between`: array of two numbers
-- `not between`: array of two numbers
+- `between`: array of two strings and/or numbers
+- `not between`: array of two strings and/or numbers
 
 ### Defining the Schema
 

--- a/src/adapters/knex.js
+++ b/src/adapters/knex.js
@@ -50,8 +50,14 @@ class KnexAdapter extends BaseAdapter {
       'filter:not like': schema.string(),
       'filter:ilike': schema.string(),
       'filter:not ilike': schema.string(),
-      'filter:between': schema.array().length(2).items(schema.number()),
-      'filter:not between': schema.array().length(2).items(schema.number()),
+      'filter:between': schema
+        .array()
+        .length(2)
+        .items(schema.number(), schema.string()),
+      'filter:not between': schema
+        .array()
+        .length(2)
+        .items(schema.number(), schema.string()),
     }
   }
 

--- a/test/src/adapters/knex.js
+++ b/test/src/adapters/knex.js
@@ -487,6 +487,14 @@ describe('validation', () => {
       ).toBe(true)
     })
 
+    test('permits an array of two string values', () => {
+      const validator = new KnexAdapter().validator
+
+      expect(
+        validator.validateValue('filter:between', 'test', ['test', 'test'])
+      ).toBe(true)
+    })
+
     test('throws for a non-permitted value', () => {
       const validator = new KnexAdapter().validator
 
@@ -502,6 +510,14 @@ describe('validation', () => {
 
       expect(
         validator.validateValue('filter:not between', 'test', [123, 456])
+      ).toBe(true)
+    })
+
+    test('permits an array of two string values', () => {
+      const validator = new KnexAdapter().validator
+
+      expect(
+        validator.validateValue('filter:not between', 'test', ['test', 'test'])
       ).toBe(true)
     })
 


### PR DESCRIPTION
Fixes #19.