### PR TITLE
BREAKING Use validated values to allow coercion

### DIFF
--- a/src/orchestrators/filterer.js
+++ b/src/orchestrators/filterer.js
@@ -31,11 +31,11 @@ class Filterer extends BaseOrchestrator {
       return true
     }
 
-    return (
-      this.parser.validate() &&
-      this.querier.adapter.validator.validateFilters(this.parse()) &&
-      this.querier.validator.validate(this.parser.flatten(this.parse()))
-    )
+    this.parser.validate()
+    this.querier.adapter.validator.validateFilters(this.parse())
+    this.querier.validator.validateFilters(this.parse())
+
+    return true
   }
 
   run() {

--- a/src/orchestrators/pager.js
+++ b/src/orchestrators/pager.js
@@ -28,11 +28,11 @@ class Pager extends BaseOrchestrator {
       return true
     }
 
-    return (
-      this.parser.validate() &&
-      this.querier.adapter.validator.validatePage(this.parse()) &&
-      this.querier.validator.validate(this.parser.flatten(this.parse()))
-    )
+    this.parser.validate()
+    this.querier.adapter.validator.validatePage(this.parse())
+    this.querier.validator.validatePage(this.parse())
+
+    return true
   }
 
   run() {

--- a/src/orchestrators/sorter.js
+++ b/src/orchestrators/sorter.js
@@ -28,11 +28,11 @@ class Sorter extends BaseOrchestrator {
       return true
     }
 
-    return (
-      this.parser.validate() &&
-      this.querier.adapter.validator.validateSorts(this.parse()) &&
-      this.querier.validator.validate(this.parser.flatten(this.parse()))
-    )
+    this.parser.validate()
+    this.querier.adapter.validator.validateSorts(this.parse())
+    this.querier.validator.validateSorts(this.parse())
+
+    return true
   }
 
   run() {

--- a/src/parsers/base.js
+++ b/src/parsers/base.js
@@ -50,7 +50,9 @@ class BaseParser {
   }
 
   validate() {
-    return this.validator.validate()
+    this.query = this.validator.validate()
+
+    return this.query
   }
 }
 

--- a/src/validators/parser.js
+++ b/src/validators/parser.js
@@ -15,16 +15,16 @@ class ParserValidator {
 
   validate() {
     if (!this.schema) {
-      return true
+      return this.query
     }
 
-    const { error } = this.schema.validate(this.query)
+    const { value, error } = this.schema.validate(this.query)
 
     if (error) {
       throw this.buildError(error)
     }
 
-    return true
+    return value
   }
 }
 

--- a/src/validators/querier/base.js
+++ b/src/validators/querier/base.js
@@ -6,7 +6,15 @@ class BaseValidator {
     this.schema = defineSchema(...this.defineSchemaArgs)
   }
 
-  validate(/* values */) {
+  validateFilters(/* filters */) {
+    throw new NotImplementedError()
+  }
+
+  validateSorts(/* sorts */) {
+    throw new NotImplementedError()
+  }
+
+  validatePage(/* page */) {
     throw new NotImplementedError()
   }
 

--- a/src/validators/querier/joi.js
+++ b/src/validators/querier/joi.js
@@ -16,22 +16,66 @@ class JoiValidator extends BaseValidator {
     return [Joi]
   }
 
-  buildError(error) {
-    return joiValidationErrorConverter(error)
+  buildError(error, key) {
+    return joiValidationErrorConverter(error, key)
   }
 
-  validate(values) {
-    if (!this.schema) {
-      return true
+  validateValue(key, value) {
+    let keySchema
+
+    try {
+      keySchema = this.schema && this.schema.extract(key)
+    } catch (error) {
+      // Don't throw error if key doesn't exist.
     }
 
-    const { error } = this.schema.validate(values, { allowUnknown: true })
+    if (!keySchema) {
+      return value
+    }
+
+    const { value: valueValidated, error } = keySchema.validate(value)
 
     if (error) {
-      throw this.buildError(error)
+      throw this.buildError(error, key)
     }
 
-    return true
+    return valueValidated
+  }
+
+  validateFilters(filters) {
+    if (!this.schema) {
+      return filters
+    }
+
+    for (const [key, filter] of filters) {
+      filter.value = this.validateValue(key, filter.value)
+    }
+
+    return filters
+  }
+
+  validateSorts(sorts) {
+    if (!this.schema) {
+      return sorts
+    }
+
+    for (const [key, sort] of sorts) {
+      sort.order = this.validateValue(key, sort.order)
+    }
+
+    return sorts
+  }
+
+  validatePage(page) {
+    if (!this.schema) {
+      return page
+    }
+
+    for (const [key, pageField] of page) {
+      pageField.value = this.validateValue(key, pageField.value)
+    }
+
+    return page
   }
 }
 

--- a/test/src/adapters/knex.js
+++ b/test/src/adapters/knex.js
@@ -202,13 +202,13 @@ describe('validation', () => {
     test('permits a number value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:=', 'test', 123)).toBe(true)
+      expect(validator.validateValue('filter:=', 'test', 123)).toBe(123)
     })
 
     test('permits a string value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:=', 'test', 'valid')).toBe(true)
+      expect(validator.validateValue('filter:=', 'test', 'valid')).toBe('valid')
     })
 
     test('throws for a non-permitted value', () => {
@@ -230,13 +230,15 @@ describe('validation', () => {
     test('permits a number value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:!=', 'test', 123)).toBe(true)
+      expect(validator.validateValue('filter:!=', 'test', 123)).toBe(123)
     })
 
     test('permits a string value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:!=', 'test', 'valid')).toBe(true)
+      expect(validator.validateValue('filter:!=', 'test', 'valid')).toBe(
+        'valid'
+      )
     })
 
     test('throws for a non-permitted value', () => {
@@ -258,13 +260,15 @@ describe('validation', () => {
     test('permits a number value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:<>', 'test', 123)).toBe(true)
+      expect(validator.validateValue('filter:<>', 'test', 123)).toBe(123)
     })
 
     test('permits a string value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:<>', 'test', 'valid')).toBe(true)
+      expect(validator.validateValue('filter:<>', 'test', 'valid')).toBe(
+        'valid'
+      )
     })
 
     test('throws for a non-permitted value', () => {
@@ -280,13 +284,13 @@ describe('validation', () => {
     test('permits a number value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:>', 'test', 123)).toBe(true)
+      expect(validator.validateValue('filter:>', 'test', 123)).toBe(123)
     })
 
     test('permits a string value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:>', 'test', 'valid')).toBe(true)
+      expect(validator.validateValue('filter:>', 'test', 'valid')).toBe('valid')
     })
 
     test('throws for a non-permitted value', () => {
@@ -302,13 +306,15 @@ describe('validation', () => {
     test('permits a number value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:>=', 'test', 123)).toBe(true)
+      expect(validator.validateValue('filter:>=', 'test', 123)).toBe(123)
     })
 
     test('permits a string value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:>=', 'test', 'valid')).toBe(true)
+      expect(validator.validateValue('filter:>=', 'test', 'valid')).toBe(
+        'valid'
+      )
     })
 
     test('throws for a non-permitted value', () => {
@@ -324,13 +330,13 @@ describe('validation', () => {
     test('permits a number value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:<', 'test', 123)).toBe(true)
+      expect(validator.validateValue('filter:<', 'test', 123)).toBe(123)
     })
 
     test('permits a string value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:<', 'test', 'valid')).toBe(true)
+      expect(validator.validateValue('filter:<', 'test', 'valid')).toBe('valid')
     })
 
     test('throws for a non-permitted value', () => {
@@ -346,13 +352,15 @@ describe('validation', () => {
     test('permits a number value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:<=', 'test', 123)).toBe(true)
+      expect(validator.validateValue('filter:<=', 'test', 123)).toBe(123)
     })
 
     test('permits a string value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:<=', 'test', 'valid')).toBe(true)
+      expect(validator.validateValue('filter:<=', 'test', 'valid')).toBe(
+        'valid'
+      )
     })
 
     test('throws for a non-permitted value', () => {
@@ -368,7 +376,7 @@ describe('validation', () => {
     test('permits a `null` value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:is', 'test', null)).toBe(true)
+      expect(validator.validateValue('filter:is', 'test', null)).toBeNull()
     })
 
     test('throws for a non-permitted value', () => {
@@ -384,7 +392,7 @@ describe('validation', () => {
     test('permits a `null` value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:is not', 'test', null)).toBe(true)
+      expect(validator.validateValue('filter:is not', 'test', null)).toBeNull()
     })
 
     test('throws for a non-permitted value', () => {
@@ -400,9 +408,9 @@ describe('validation', () => {
     test('permits an array of number / string values', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:in', 'test', [123, 'test'])).toBe(
-        true
-      )
+      expect(
+        validator.validateValue('filter:in', 'test', [123, 'test'])
+      ).toEqual([123, 'test'])
     })
 
     test('throws for a non-permitted value', () => {
@@ -420,7 +428,7 @@ describe('validation', () => {
 
       expect(
         validator.validateValue('filter:not in', 'test', [123, 'test'])
-      ).toBe(true)
+      ).toEqual([123, 'test'])
     })
 
     test('throws for a non-permitted value', () => {
@@ -436,7 +444,9 @@ describe('validation', () => {
     test('permits a string value', () => {
       const validator = new KnexAdapter().validator
 
-      expect(validator.validateValue('filter:like', 'test', 'valid')).toBe(true)
+      expect(validator.validateValue('filter:like', 'test', 'valid')).toBe(
+        'valid'
+      )
     })
 
     test('throws for a non-permitted value', () => {
@@ -453,7 +463,7 @@ describe('validation', () => {
       const validator = new KnexAdapter().validator
 
       expect(validator.validateValue('filter:not like', 'test', 'valid')).toBe(
-        true
+        'valid'
       )
     })
 
@@ -471,7 +481,7 @@ describe('validation', () => {
       const validator = new KnexAdapter().validator
 
       expect(validator.validateValue('filter:ilike', 'test', 'valid')).toBe(
-        true
+        'valid'
       )
     })
 
@@ -489,7 +499,7 @@ describe('validation', () => {
       const validator = new KnexAdapter().validator
 
       expect(validator.validateValue('filter:not ilike', 'test', 'valid')).toBe(
-        true
+        'valid'
       )
     })
 
@@ -508,7 +518,7 @@ describe('validation', () => {
 
       expect(
         validator.validateValue('filter:between', 'test', [123, 456])
-      ).toBe(true)
+      ).toEqual([123, 456])
     })
 
     test('permits an array of two string values', () => {
@@ -516,7 +526,7 @@ describe('validation', () => {
 
       expect(
         validator.validateValue('filter:between', 'test', ['test', 'test'])
-      ).toBe(true)
+      ).toEqual(['test', 'test'])
     })
 
     test('throws for a non-permitted value', () => {
@@ -534,7 +544,7 @@ describe('validation', () => {
 
       expect(
         validator.validateValue('filter:not between', 'test', [123, 456])
-      ).toBe(true)
+      ).toEqual([123, 456])
     })
 
     test('permits an array of two string values', () => {
@@ -542,7 +552,7 @@ describe('validation', () => {
 
       expect(
         validator.validateValue('filter:not between', 'test', ['test', 'test'])
-      ).toBe(true)
+      ).toEqual(['test', 'test'])
     })
 
     test('throws for a non-permitted value', () => {

--- a/test/src/parsers/base.js
+++ b/test/src/parsers/base.js
@@ -96,7 +96,7 @@ describe('defaults', () => {
 })
 
 describe('validate', () => {
-  test('returns `true` if valid', () => {
+  test('returns the validated query if valid', () => {
     const defineValidation = jest
       .spyOn(BaseParser.prototype, 'defineValidation')
       .mockImplementation((schema) =>
@@ -107,12 +107,12 @@ describe('validate', () => {
 
     const parser = new BaseParser('test', { test: 123 }, new Schema())
 
-    expect(parser.validate()).toBe(true)
+    expect(parser.validate()).toEqual({ test: 123 })
 
     defineValidation.mockRestore()
   })
 
-  test('returns the cached `true` on subsequent calls', () => {
+  test('returns the cached validated query on subsequent calls', () => {
     const defineValidation = jest
       .spyOn(BaseParser.prototype, 'defineValidation')
       .mockImplementation((schema) =>
@@ -125,8 +125,8 @@ describe('validate', () => {
 
     const validate = jest.spyOn(parser.validator, 'validate')
 
-    expect(parser.validate()).toBe(true)
-    expect(parser.validate()).toBe(true)
+    expect(parser.validate()).toEqual({ test: 123 })
+    expect(parser.validate()).toEqual({ test: 123 })
     expect(validate).toHaveBeenCalledTimes(1)
 
     defineValidation.mockRestore()

--- a/test/src/parsers/page.js
+++ b/test/src/parsers/page.js
@@ -125,7 +125,7 @@ describe('parse', () => {
 
     expect(parsed.get('page:number')).toEqual({
       field: 'number',
-      value: '2',
+      value: 2,
     })
 
     expect(parsed.get('page:offset')).toEqual({
@@ -165,7 +165,7 @@ describe('parse', () => {
 
     expect(parsed.get('page:number')).toEqual({
       field: 'number',
-      value: '2',
+      value: 2,
     })
 
     expect(parsed.get('page:offset')).toEqual({
@@ -180,7 +180,7 @@ describe('parse', () => {
 
     expect(parsed.get('page:size')).toEqual({
       field: 'size',
-      value: '10',
+      value: 10,
     })
 
     expect(parsed.get('page:number')).toEqual({
@@ -204,12 +204,12 @@ describe('parse', () => {
 
     expect(parsed.get('page:size')).toEqual({
       field: 'size',
-      value: '10',
+      value: 10,
     })
 
     expect(parsed.get('page:number')).toEqual({
       field: 'number',
-      value: '2',
+      value: 2,
     })
 
     expect(parsed.get('page:offset')).toEqual({

--- a/test/src/validators/adapter.js
+++ b/test/src/validators/adapter.js
@@ -15,7 +15,7 @@ describe('constructor', () => {
     const validator = new AdapterValidator(defineSchema)
 
     expect(defineSchema).toHaveBeenCalledWith(Joi)
-    expect(validator.schema).toEqual(schema)
+    expect(Joi.isSchema(validator.schema)).toBe(true)
   })
 })
 
@@ -35,34 +35,30 @@ describe('buildError', () => {
 })
 
 describe('validateValue', () => {
-  test('returns `true` if no schema is defined', () => {
+  test('returns the value if no schema is defined', () => {
     const validator = new AdapterValidator(() => {})
 
     expect(validator.schema).toBeUndefined()
-    expect(validator.validateValue('filter:=', 'filter:test[=]', 123)).toBe(
-      true
-    )
+    expect(validator.validateValue('filter:=', 'filter:test[=]', 123)).toBe(123)
   })
 
-  test('returns `true` if no schema key is defined', () => {
+  test('returns the value if no schema key is defined', () => {
     const validator = new AdapterValidator((schema) => ({
       'filter:=': schema.number(),
     }))
 
-    expect(validator.schema['filter:!=']).toBeUndefined()
+    expect(() => validator.schema.extract('filter:!=')).toThrow()
     expect(validator.validateValue('filter:!=', 'filter:test[!=]', 123)).toBe(
-      true
+      123
     )
   })
 
-  test('returns `true` if valid', () => {
+  test('returns the value if valid', () => {
     const validator = new AdapterValidator((schema) => ({
       'filter:=': schema.number(),
     }))
 
-    expect(validator.validateValue('filter:=', 'filter:test[=]', 123)).toBe(
-      true
-    )
+    expect(validator.validateValue('filter:=', 'filter:test[=]', 123)).toBe(123)
   })
 
   test('throws `ValidationError` if invalid', () => {
@@ -77,7 +73,7 @@ describe('validateValue', () => {
 })
 
 describe('validateFilters', () => {
-  test('returns `true` if no schema is defined', () => {
+  test('returns the parsed filters if no schema is defined', () => {
     const parser = new FilterParser(
       'filter',
       { test: { '=': 123 } },
@@ -86,10 +82,10 @@ describe('validateFilters', () => {
     const validator = new AdapterValidator(() => {})
 
     expect(validator.schema).toBeUndefined()
-    expect(validator.validateFilters(parser.parse())).toBe(true)
+    expect(validator.validateFilters(parser.parse())).toBeInstanceOf(Map)
   })
 
-  test('returns `true` if all filters are valid', () => {
+  test('returns the parsed filters if all filters are valid', () => {
     const parser = new FilterParser(
       'filter',
       {
@@ -105,7 +101,7 @@ describe('validateFilters', () => {
       'filter:!=': schema.number(),
     }))
 
-    expect(validator.validateFilters(parser.parse())).toBe(true)
+    expect(validator.validateFilters(parser.parse())).toBeInstanceOf(Map)
   })
 
   test('throws `ValidationError` if a filter is invalid', () => {
@@ -125,25 +121,15 @@ describe('validateFilters', () => {
 })
 
 describe('validateSorts', () => {
-  test('returns `true` if no schema is defined', () => {
+  test('returns the parsed sorts if no schema is defined', () => {
     const parser = new SortParser('sort', 'test', new Schema().sort('test'))
     const validator = new AdapterValidator(() => {})
 
     expect(validator.schema).toBeUndefined()
-    expect(validator.validateSorts(parser.parse())).toBe(true)
+    expect(validator.validateSorts(parser.parse())).toBeInstanceOf(Map)
   })
 
-  test('returns `true` if no schema key is defined', () => {
-    const parser = new SortParser('sort', 'test', new Schema().sort('test'))
-    const validator = new AdapterValidator((schema) => ({
-      'filter:=': schema.number(),
-    }))
-
-    expect(validator.schema['sort']).toBeUndefined()
-    expect(validator.validateSorts(parser.parse())).toBe(true)
-  })
-
-  test('returns `true` if all sorts are valid', () => {
+  test('returns the parsed sorts if all sorts are valid', () => {
     const parser = new SortParser(
       'sort',
       ['test1', 'test2'],
@@ -153,7 +139,7 @@ describe('validateSorts', () => {
       sort: schema.string().valid('asc'),
     }))
 
-    expect(validator.validateSorts(parser.parse())).toBe(true)
+    expect(validator.validateSorts(parser.parse())).toBeInstanceOf(Map)
   })
 
   test('throws `ValidationError` if a sort is invalid', () => {
@@ -169,22 +155,22 @@ describe('validateSorts', () => {
 })
 
 describe('validatePage', () => {
-  test('returns `true` if no schema is defined', () => {
+  test('returns the parsed page if no schema is defined', () => {
     const parser = new PageParser('page', '2', new Schema())
     const validator = new AdapterValidator(() => {})
 
     expect(validator.schema).toBeUndefined()
-    expect(validator.validatePage(parser.parse())).toBe(true)
+    expect(validator.validatePage(parser.parse())).toBeInstanceOf(Map)
   })
 
-  test('returns `true` if page is valid', () => {
+  test('returns the parsed page if page is valid', () => {
     const parser = new PageParser('page', '2', new Schema())
     const validator = new AdapterValidator((schema) => ({
       'page:size': schema.number().valid(20),
       'page:number': schema.number().valid(2),
     }))
 
-    expect(validator.validatePage(parser.parse())).toBe(true)
+    expect(validator.validatePage(parser.parse())).toBeInstanceOf(Map)
   })
 
   test('throws `ValidationError` if page is invalid', () => {

--- a/test/src/validators/parser.js
+++ b/test/src/validators/parser.js
@@ -44,21 +44,21 @@ describe('buildError', () => {
 })
 
 describe('validate', () => {
-  test('returns `true` if no schema is defined', () => {
+  test('returns the value if no schema is defined', () => {
     const validator = new ParserValidator(() => {}, 'test', 123)
 
     expect(validator.schema).toBeUndefined()
-    expect(validator.validate()).toBe(true)
+    expect(validator.validate()).toBe(123)
   })
 
-  test('returns `true` if valid', () => {
+  test('returns the value if valid', () => {
     const validator = new ParserValidator(
       (schema) => schema.number(),
       'test',
       123
     )
 
-    expect(validator.validate()).toBe(true)
+    expect(validator.validate()).toBe(123)
   })
 
   test('throws `ValidationError` if invalid', () => {

--- a/test/src/validators/querier/base.js
+++ b/test/src/validators/querier/base.js
@@ -12,11 +12,27 @@ describe('constructor', () => {
   })
 })
 
-describe('validate', () => {
+describe('validateFilters', () => {
   test('throws `NotImplementedError` when not extended', () => {
     const validator = new BaseValidator(() => {})
 
-    expect(() => validator.validate()).toThrow(NotImplementedError)
+    expect(() => validator.validateFilters()).toThrow(NotImplementedError)
+  })
+})
+
+describe('validateSorts', () => {
+  test('throws `NotImplementedError` when not extended', () => {
+    const validator = new BaseValidator(() => {})
+
+    expect(() => validator.validateSorts()).toThrow(NotImplementedError)
+  })
+})
+
+describe('validatePage', () => {
+  test('throws `NotImplementedError` when not extended', () => {
+    const validator = new BaseValidator(() => {})
+
+    expect(() => validator.validatePage()).toThrow(NotImplementedError)
   })
 })
 

--- a/test/src/validators/querier/joi.js
+++ b/test/src/validators/querier/joi.js
@@ -1,6 +1,10 @@
 const Joi = require('@hapi/joi')
 
+const FilterParser = require('../../../../src/parsers/filter')
 const JoiValidator = require('../../../../src/validators/querier/joi')
+const PageParser = require('../../../../src/parsers/page')
+const Schema = require('../../../../src/schema')
+const SortParser = require('../../../../src/parsers/sort')
 const ValidationError = require('../../../../src/errors/validation')
 
 describe('constructor', () => {
@@ -38,20 +42,29 @@ describe('buildError', () => {
   })
 })
 
-describe('validate', () => {
-  test('returns `true` if no schema is defined', () => {
+describe('validateValue', () => {
+  test('returns the value if no schema is defined', () => {
     const validator = new JoiValidator(() => {})
 
     expect(validator.schema).toBeUndefined()
-    expect(validator.validate({ 'filter:test[=]': 123 })).toBe(true)
+    expect(validator.validateValue('filter:test[=]', 123)).toBe(123)
   })
 
-  test('returns `true` if valid', () => {
+  test('returns the value if no schema key is defined', () => {
     const validator = new JoiValidator((schema) => ({
       'filter:test[=]': schema.number(),
     }))
 
-    expect(validator.validate({ 'filter:test[=]': 123 })).toBe(true)
+    expect(() => validator.schema.extract('filter:text[!=]')).toThrow()
+    expect(validator.validateValue('filter:test[!=]', 123)).toBe(123)
+  })
+
+  test('returns the value if valid', () => {
+    const validator = new JoiValidator((schema) => ({
+      'filter:test[=]': schema.number(),
+    }))
+
+    expect(validator.validateValue('filter:test[=]', 123)).toBe(123)
   })
 
   test('throws `ValidationError` if invalid', () => {
@@ -59,8 +72,121 @@ describe('validate', () => {
       'filter:test[=]': schema.number(),
     }))
 
-    expect(() => validator.validate({ 'filter:test[=]': 'invalid' })).toThrow(
+    expect(() => validator.validateValue('filter:test[=]', 'invalid')).toThrow(
       new ValidationError('filter:test[=] must be a number')
+    )
+  })
+})
+
+describe('validateFilters', () => {
+  test('returns the parsed filters if no schema is defined', () => {
+    const parser = new FilterParser(
+      'filter',
+      { test: { '=': 123 } },
+      new Schema().filter('test', '=')
+    )
+    const validator = new JoiValidator(() => {})
+
+    expect(validator.schema).toBeUndefined()
+    expect(validator.validateFilters(parser.parse())).toBeInstanceOf(Map)
+  })
+
+  test('returns the parsed filters if all filters are valid', () => {
+    const parser = new FilterParser(
+      'filter',
+      {
+        test: {
+          '=': 123,
+          '!=': 456,
+        },
+      },
+      new Schema().filter('test', '=').filter('test', '!=')
+    )
+    const validator = new JoiValidator((schema) => ({
+      'filter:test[=]': schema.number(),
+      'filter:test[!=]': schema.number(),
+    }))
+
+    expect(validator.validateFilters(parser.parse())).toBeInstanceOf(Map)
+  })
+
+  test('throws `ValidationError` if a filter is invalid', () => {
+    const parser = new FilterParser(
+      'filter',
+      { test: { '=': 'invalid' } },
+      new Schema().filter('test', '=')
+    )
+    const validator = new JoiValidator((schema) => ({
+      'filter:test[=]': schema.number(),
+    }))
+
+    expect(() => validator.validateFilters(parser.parse())).toThrow(
+      new ValidationError('filter:test[=] must be a number')
+    )
+  })
+})
+
+describe('validateSorts', () => {
+  test('returns the parsed sorts if no schema is defined', () => {
+    const parser = new SortParser('sort', 'test', new Schema().sort('test'))
+    const validator = new JoiValidator(() => {})
+
+    expect(validator.schema).toBeUndefined()
+    expect(validator.validateSorts(parser.parse())).toBeInstanceOf(Map)
+  })
+
+  test('returns the parsed sorts if all sorts are valid', () => {
+    const parser = new SortParser(
+      'sort',
+      ['test1', 'test2'],
+      new Schema().sort('test1').sort('test2')
+    )
+    const validator = new JoiValidator((schema) => ({
+      'sort:test1': schema.string().valid('asc'),
+    }))
+
+    expect(validator.validateSorts(parser.parse())).toBeInstanceOf(Map)
+  })
+
+  test('throws `ValidationError` if a sort is invalid', () => {
+    const parser = new SortParser('sort', 'test', new Schema().sort('test'))
+    const validator = new JoiValidator((schema) => ({
+      'sort:test': schema.string().invalid('asc'),
+    }))
+
+    expect(() => validator.validateSorts(parser.parse())).toThrow(
+      new ValidationError('sort:test contains an invalid value')
+    )
+  })
+})
+
+describe('validatePage', () => {
+  test('returns the parsed page if no schema is defined', () => {
+    const parser = new PageParser('page', '2', new Schema())
+    const validator = new JoiValidator(() => {})
+
+    expect(validator.schema).toBeUndefined()
+    expect(validator.validatePage(parser.parse())).toBeInstanceOf(Map)
+  })
+
+  test('returns the parsed page if page is valid', () => {
+    const parser = new PageParser('page', '2', new Schema())
+    const validator = new JoiValidator((schema) => ({
+      'page:size': schema.number().valid(20),
+      'page:number': schema.number().valid(2),
+    }))
+
+    expect(validator.validatePage(parser.parse())).toBeInstanceOf(Map)
+  })
+
+  test('throws `ValidationError` if page is invalid', () => {
+    const parser = new PageParser('page', '2', new Schema())
+    const validator = new JoiValidator((schema) => ({
+      'page:number': schema.number().invalid(2),
+    }))
+
+    expect(() => validator.validatePage(parser.parse())).toThrow(
+      new ValidationError('page:number contains an invalid value')
     )
   })
 })


### PR DESCRIPTION
For most, this should _not_ be a breaking change.

It's only breaking if you

- directly interact with one of the internal validators, such
  `AdapterValidator` or `ParserValidator`;
- have created your own querier validator that extends `BaseValidator`;
- or rely on parsed values
  (i.e., `querier.pager.parse().get('page:size').value`) being the exact
  same type/value that was passed into the querier (they're now coerced
  by validation).