### PR TITLE
BREAKING Add `field` option if different than name

### DIFF
--- a/src/adapters/base.js
+++ b/src/adapters/base.js
@@ -16,11 +16,11 @@ class BaseAdapter {
     throw new NotImplementedError()
   }
 
-  'filter:*'(/* builder, { field, operator, value } */) {
+  'filter:*'(/* builder, { name, field, operator, value } */) {
     throw new NotImplementedError()
   }
 
-  sort(/* builder, { field, order } */) {
+  sort(/* builder, { name, field, order } */) {
     throw new NotImplementedError()
   }
 

--- a/src/parsers/sort.js
+++ b/src/parsers/sort.js
@@ -6,13 +6,14 @@ const flattenMap = require('../services/flatten_map')
 class SortParser extends BaseParser {
   static get DEFAULTS() {
     return {
+      name: null,
       field: null,
       order: 'asc',
     }
   }
 
-  buildKey({ field }) {
-    return `${this.queryKey}:${field}`
+  buildKey({ name }) {
+    return `${this.queryKey}:${name}`
   }
 
   defineValidation(schema) {
@@ -44,26 +45,39 @@ class SortParser extends BaseParser {
     })
   }
 
-  parseString(field) {
+  parseString(name) {
+    const { options } = this.schema.sorts.get(name)
+
     return {
       ...this.defaults,
-      field,
+      name,
+      field: options.field || name,
     }
   }
 
-  parseArray(fields) {
-    return fields.map((field) => ({
-      ...this.defaults,
-      field,
-    }))
+  parseArray(names) {
+    return names.map((name) => {
+      const { options } = this.schema.sorts.get(name)
+
+      return {
+        ...this.defaults,
+        name,
+        field: options.field || name,
+      }
+    })
   }
 
   parseObject(query) {
-    return Object.entries(query).map(([field, order]) => ({
-      ...this.defaults,
-      field,
-      order,
-    }))
+    return Object.entries(query).map(([name, order]) => {
+      const { options } = this.schema.sorts.get(name)
+
+      return {
+        ...this.defaults,
+        name,
+        field: options.field || name,
+        order,
+      }
+    })
   }
 
   parse() {

--- a/src/schema.js
+++ b/src/schema.js
@@ -7,14 +7,14 @@ class Schema {
     this.page(false)
   }
 
-  filter(field, operatorOrOperators, options = {}) {
+  filter(name, operatorOrOperators, options = {}) {
     const operators = Array.isArray(operatorOrOperators)
       ? operatorOrOperators
       : [operatorOrOperators]
 
     for (const operator of operators) {
-      this.filters.set(`${field}[${operator}]`, {
-        field,
+      this.filters.set(`${name}[${operator}]`, {
+        name,
         operator,
         options,
       })
@@ -23,9 +23,9 @@ class Schema {
     return this
   }
 
-  sort(field, options = {}) {
-    this.sorts.set(field, {
-      field,
+  sort(name, options = {}) {
+    this.sorts.set(name, {
+      name,
       options,
     })
 
@@ -48,15 +48,15 @@ class Schema {
     return this
   }
 
-  mapFilterFieldsToOperators() {
+  mapFilterNamesToOperators() {
     const filters = Array.from(this.filters.values())
 
     return filters.reduce((accumulator, filter) => {
-      if (!accumulator[filter.field]) {
-        accumulator[filter.field] = []
+      if (!accumulator[filter.name]) {
+        accumulator[filter.name] = []
       }
 
-      accumulator[filter.field].push(filter.operator)
+      accumulator[filter.name].push(filter.operator)
 
       return accumulator
     }, {})

--- a/test/src/adapters/knex.js
+++ b/test/src/adapters/knex.js
@@ -4,9 +4,27 @@ const KnexAdapter = require('../../../src/adapters/knex')
 const ValidationError = require('../../../src/errors/validation')
 
 describe('filter', () => {
+  test('uses `field` for the column, not `name`', () => {
+    const query = new KnexAdapter()
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'testing',
+        operator: '=',
+        value: 123,
+      })
+      .toString()
+
+    expect(query).toBe('select * from "test" where "testing" = 123')
+  })
+
   test('supports the `=` operator', () => {
     const query = new KnexAdapter()
-      .filter(knex('test'), { field: 'test', operator: '=', value: 123 })
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'test',
+        operator: '=',
+        value: 123,
+      })
       .toString()
 
     expect(query).toBe('select * from "test" where "test" = 123')
@@ -14,7 +32,12 @@ describe('filter', () => {
 
   test('supports the `!=` operator', () => {
     const query = new KnexAdapter()
-      .filter(knex('test'), { field: 'test', operator: '!=', value: 123 })
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'test',
+        operator: '!=',
+        value: 123,
+      })
       .toString()
 
     expect(query).toBe('select * from "test" where "test" != 123')
@@ -22,7 +45,12 @@ describe('filter', () => {
 
   test('supports the `<>` operator', () => {
     const query = new KnexAdapter()
-      .filter(knex('test'), { field: 'test', operator: '<>', value: 123 })
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'test',
+        operator: '<>',
+        value: 123,
+      })
       .toString()
 
     expect(query).toBe('select * from "test" where "test" <> 123')
@@ -30,7 +58,12 @@ describe('filter', () => {
 
   test('supports the `>` operator', () => {
     const query = new KnexAdapter()
-      .filter(knex('test'), { field: 'test', operator: '>', value: 123 })
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'test',
+        operator: '>',
+        value: 123,
+      })
       .toString()
 
     expect(query).toBe('select * from "test" where "test" > 123')
@@ -38,7 +71,12 @@ describe('filter', () => {
 
   test('supports the `>=` operator', () => {
     const query = new KnexAdapter()
-      .filter(knex('test'), { field: 'test', operator: '>=', value: 123 })
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'test',
+        operator: '>=',
+        value: 123,
+      })
       .toString()
 
     expect(query).toBe('select * from "test" where "test" >= 123')
@@ -46,7 +84,12 @@ describe('filter', () => {
 
   test('supports the `<` operator', () => {
     const query = new KnexAdapter()
-      .filter(knex('test'), { field: 'test', operator: '<', value: 123 })
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'test',
+        operator: '<',
+        value: 123,
+      })
       .toString()
 
     expect(query).toBe('select * from "test" where "test" < 123')
@@ -54,7 +97,12 @@ describe('filter', () => {
 
   test('supports the `<=` operator', () => {
     const query = new KnexAdapter()
-      .filter(knex('test'), { field: 'test', operator: '<=', value: 123 })
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'test',
+        operator: '<=',
+        value: 123,
+      })
       .toString()
 
     expect(query).toBe('select * from "test" where "test" <= 123')
@@ -62,7 +110,12 @@ describe('filter', () => {
 
   test('supports the `is` operator', () => {
     const query = new KnexAdapter()
-      .filter(knex('test'), { field: 'test', operator: 'is', value: null })
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'test',
+        operator: 'is',
+        value: null,
+      })
       .toString()
 
     expect(query).toBe('select * from "test" where "test" is null')
@@ -70,7 +123,12 @@ describe('filter', () => {
 
   test('supports the `is not` operator', () => {
     const query = new KnexAdapter()
-      .filter(knex('test'), { field: 'test', operator: 'is not', value: null })
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'test',
+        operator: 'is not',
+        value: null,
+      })
       .toString()
 
     expect(query).toBe('select * from "test" where "test" is not null')
@@ -79,6 +137,7 @@ describe('filter', () => {
   test('supports the `in` operator', () => {
     const query = new KnexAdapter()
       .filter(knex('test'), {
+        name: 'test',
         field: 'test',
         operator: 'in',
         value: [123, 456],
@@ -91,6 +150,7 @@ describe('filter', () => {
   test('supports the `not in` operator', () => {
     const query = new KnexAdapter()
       .filter(knex('test'), {
+        name: 'test',
         field: 'test',
         operator: 'not in',
         value: [123, 456],
@@ -102,7 +162,12 @@ describe('filter', () => {
 
   test('supports the `like` operator', () => {
     const query = new KnexAdapter()
-      .filter(knex('test'), { field: 'test', operator: 'like', value: '%123%' })
+      .filter(knex('test'), {
+        name: 'test',
+        field: 'test',
+        operator: 'like',
+        value: '%123%',
+      })
       .toString()
 
     expect(query).toBe('select * from "test" where "test" like \'%123%\'')
@@ -111,6 +176,7 @@ describe('filter', () => {
   test('supports the `not like` operator', () => {
     const query = new KnexAdapter()
       .filter(knex('test'), {
+        name: 'test',
         field: 'test',
         operator: 'not like',
         value: '%123%',
@@ -123,6 +189,7 @@ describe('filter', () => {
   test('supports the `ilike` operator', () => {
     const query = new KnexAdapter()
       .filter(knex('test'), {
+        name: 'test',
         field: 'test',
         operator: 'ilike',
         value: '%123%',
@@ -135,6 +202,7 @@ describe('filter', () => {
   test('supports the `not ilike` operator', () => {
     const query = new KnexAdapter()
       .filter(knex('test'), {
+        name: 'test',
         field: 'test',
         operator: 'not ilike',
         value: '%123%',
@@ -147,6 +215,7 @@ describe('filter', () => {
   test('supports the `between` operator', () => {
     const query = new KnexAdapter()
       .filter(knex('test'), {
+        name: 'test',
         field: 'test',
         operator: 'between',
         value: [123, 456],
@@ -159,6 +228,7 @@ describe('filter', () => {
   test('supports the `not between` operator', () => {
     const query = new KnexAdapter()
       .filter(knex('test'), {
+        name: 'test',
         field: 'test',
         operator: 'not between',
         value: [123, 456],
@@ -174,10 +244,18 @@ describe('filter', () => {
 describe('sort', () => {
   test('adds an `order by` clause', () => {
     const query = new KnexAdapter()
-      .sort(knex('test'), { field: 'test', order: 'desc' })
+      .sort(knex('test'), { name: 'test', field: 'test', order: 'desc' })
       .toString()
 
     expect(query).toBe('select * from "test" order by "test" desc')
+  })
+
+  test('uses `field` for the column, not `name`', () => {
+    const query = new KnexAdapter()
+      .sort(knex('test'), { name: 'test', field: 'testing', order: 'desc' })
+      .toString()
+
+    expect(query).toBe('select * from "test" order by "testing" desc')
   })
 })
 

--- a/test/src/orchestrators/base.js
+++ b/test/src/orchestrators/base.js
@@ -147,6 +147,7 @@ describe('apply', () => {
     const querier = new TestQuerier({}, knex('test'))
     const orchestrator = new BaseOrchestrator(querier)
     const data = {
+      name: 'test',
       field: 'test',
       order: 'asc',
     }
@@ -162,6 +163,7 @@ describe('apply', () => {
     const querier = new TestQuerier({}, knex('test'))
     const orchestrator = new BaseOrchestrator(querier)
     const data = {
+      name: 'test',
       field: 'test',
       order: 'asc',
     }

--- a/test/src/orchestrators/filterer.js
+++ b/test/src/orchestrators/filterer.js
@@ -116,6 +116,7 @@ describe('run', () => {
     expect(filterer.apply).toHaveBeenNthCalledWith(
       1,
       {
+        name: 'test',
         field: 'test',
         operator: '=',
         value: 123,
@@ -126,6 +127,7 @@ describe('run', () => {
     expect(filterer.apply).toHaveBeenNthCalledWith(
       2,
       {
+        name: 'testing',
         field: 'testing',
         operator: '!=',
         value: 456,

--- a/test/src/orchestrators/sorter.js
+++ b/test/src/orchestrators/sorter.js
@@ -111,6 +111,7 @@ describe('run', () => {
     expect(sorter.apply).toHaveBeenNthCalledWith(
       1,
       {
+        name: 'testing',
         field: 'testing',
         order: 'asc',
       },
@@ -120,6 +121,7 @@ describe('run', () => {
     expect(sorter.apply).toHaveBeenNthCalledWith(
       2,
       {
+        name: 'test',
         field: 'test',
         order: 'asc',
       },

--- a/test/src/schema.js
+++ b/test/src/schema.js
@@ -21,7 +21,7 @@ describe('filter', () => {
     schema.filter('test', '=')
 
     expect(schema.filters.get('test[=]')).toEqual({
-      field: 'test',
+      name: 'test',
       operator: '=',
       options: {},
     })
@@ -33,12 +33,12 @@ describe('filter', () => {
     schema.filter('test', ['=', '!='])
 
     expect(schema.filters.get('test[=]')).toEqual({
-      field: 'test',
+      name: 'test',
       operator: '=',
       options: {},
     })
     expect(schema.filters.get('test[!=]')).toEqual({
-      field: 'test',
+      name: 'test',
       operator: '!=',
       options: {},
     })
@@ -46,7 +46,7 @@ describe('filter', () => {
 
   test('accepts an optional options object', () => {
     const schema = new Schema()
-    const options = { test: 123 }
+    const options = { field: 'test.test' }
 
     schema.filter('test', '=', options)
 
@@ -67,14 +67,14 @@ describe('sort', () => {
     schema.sort('test')
 
     expect(schema.sorts.get('test')).toEqual({
-      field: 'test',
+      name: 'test',
       options: {},
     })
   })
 
   test('accepts an optional options object', () => {
     const schema = new Schema()
-    const options = { test: 123 }
+    const options = { field: 'test.test' }
 
     schema.sort('test', options)
 
@@ -138,15 +138,15 @@ describe('page', () => {
   })
 })
 
-describe('mapFilterFieldsToOperators', () => {
-  test('returns object with filter fields (keys) => operators (values)', () => {
+describe('mapFilterNamesToOperators', () => {
+  test('returns object with filter names (keys) => operators (values)', () => {
     const schema = new Schema()
 
     schema.filter('test1', '=')
     schema.filter('test1', '!=')
     schema.filter('test2', 'in')
 
-    expect(schema.mapFilterFieldsToOperators()).toEqual({
+    expect(schema.mapFilterNamesToOperators()).toEqual({
       test1: ['=', '!='],
       test2: ['in'],
     })


### PR DESCRIPTION
For most, this should _not_ be a breaking change.

It's only breaking if you directly interact with the schema (i.e.,
`querier.schema`) and depend on the underlying data structures of
`filters` or `sorts`. `mapFilterFieldsToOperators` has also been renamed
to `mapFilterNamesToOperators`.