### PR TITLE
LEN-5466: update Github Action dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,10 @@ jobs:
       - name: Upload test reports
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: test-reports-${{ matrix.node-version }}
           path: test/reports
       - name: Upload test coverage
         uses: actions/upload-artifact@v4
         with:
-          name: test-coverage
+          name: test-coverage-${{ matrix.node-version }}
           path: test/coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
       - name: Run tests
         run: npm test -- --ci --coverage --runInBand
       - name: Upload test reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-reports
           path: test/reports
       - name: Upload test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-coverage
           path: test/coverage


### PR DESCRIPTION
This PR updates the dependencies in Github Actions with the primary goal to move `actions/upload-artifacts` from v3 to v4.